### PR TITLE
Add custom fetch support to transports

### DIFF
--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -262,6 +262,36 @@ describe("SSEClientTransport", () => {
       expect(lastServerRequest.headers.authorization).toBe(authToken);
     });
 
+    it("uses custom fetch implementation from options", async () => {
+      const authToken = "Bearer custom-token";
+
+      const fetchWithAuth = jest.fn((url: string | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        headers.set("Authorization", authToken);
+        return fetch(url.toString(), { ...init, headers });
+      });
+
+      transport = new SSEClientTransport(resourceBaseUrl, {
+        fetch: fetchWithAuth,
+      });
+
+      await transport.start();
+
+      expect(lastServerRequest.headers.authorization).toBe(authToken);
+
+      // Send a message to verify fetchWithAuth used for POST as well
+      const message: JSONRPCMessage = {
+        jsonrpc: "2.0",
+        id: "1",
+        method: "test",
+        params: {},
+      };
+
+      await transport.send(message);
+
+      expect(fetchWithAuth).toHaveBeenCalled();
+    });
+
     it("passes custom headers to fetch requests", async () => {
       const customHeaders = {
         Authorization: "Bearer test-token",

--- a/src/client/sse.test.ts
+++ b/src/client/sse.test.ts
@@ -289,7 +289,9 @@ describe("SSEClientTransport", () => {
 
       await transport.send(message);
 
-      expect(fetchWithAuth).toHaveBeenCalled();
+      expect(fetchWithAuth).toHaveBeenCalledTimes(2);
+      expect(lastServerRequest.method).toBe("POST");
+      expect(lastServerRequest.headers.authorization).toBe(authToken);
     });
 
     it("passes custom headers to fetch requests", async () => {

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -1,9 +1,7 @@
 import { EventSource, type ErrorEvent, type EventSourceInit } from "eventsource";
-import { Transport } from "../shared/transport.js";
+import { Transport, FetchLike } from "../shared/transport.js";
 import { JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
-
-export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 
 export class SseError extends Error {
   constructor(

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -126,7 +126,7 @@ export class SSEClientTransport implements Transport {
   }
 
   private _startOrAuth(): Promise<void> {
-    const fetchImpl = (this?._eventSourceInit?.fetch || this._fetch || fetch) as typeof fetch
+const fetchImpl = (this?._eventSourceInit?.fetch ?? this._fetch ?? fetch) as typeof fetch
     return new Promise((resolve, reject) => {
       this._eventSource = new EventSource(
         this._url.href,

--- a/src/client/sse.ts
+++ b/src/client/sse.ts
@@ -251,7 +251,7 @@ const fetchImpl = (this?._eventSourceInit?.fetch ?? this._fetch ?? fetch) as typ
         signal: this._abortController?.signal,
       };
 
-      const response = await (this._fetch ?? fetch)(this._endpoint, init);
+const response = await (this._fetch ?? fetch)(this._endpoint, init);
       if (!response.ok) {
         if (response.status === 401 && this._authProvider) {
 

--- a/src/client/streamableHttp.test.ts
+++ b/src/client/streamableHttp.test.ts
@@ -1,4 +1,4 @@
-import { StreamableHTTPClientTransport, StreamableHTTPReconnectionOptions } from "./streamableHttp.js";
+import { StreamableHTTPClientTransport, StreamableHTTPReconnectionOptions, StartSSEOptions } from "./streamableHttp.js";
 import { OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { JSONRPCMessage } from "../types.js";
 
@@ -461,7 +461,7 @@ describe("StreamableHTTPClientTransport", () => {
     transport = new StreamableHTTPClientTransport(new URL("http://localhost:1234/mcp"), { fetch: fetchWithAuth });
 
     await transport.start();
-    await (transport as unknown as { _startOrAuthSse: (opts: any) => Promise<void> })._startOrAuthSse({});
+    await (transport as unknown as { _startOrAuthSse: (opts: StartSSEOptions) => Promise<void> })._startOrAuthSse({});
 
     await transport.send({ jsonrpc: "2.0", method: "test", params: {}, id: "1" } as JSONRPCMessage);
 
@@ -559,7 +559,7 @@ describe("StreamableHTTPClientTransport", () => {
     // Second retry - should double (2^1 * 100 = 200)
     expect(getDelay(1)).toBe(200);
 
-    // Third retry - should double again (2^2 * 100 = 400) 
+    // Third retry - should double again (2^2 * 100 = 400)
     expect(getDelay(2)).toBe(400);
 
     // Fourth retry - should double again (2^3 * 100 = 800)

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -529,7 +529,7 @@ const response = await (this._fetch ?? fetch)(this._url, init);
         signal: this._abortController?.signal,
       };
 
-      const response = await (this._fetch ?? fetch)(this._url, init);
+const response = await (this._fetch ?? fetch)(this._url, init);
 
       // We specifically handle 405 as a valid response according to the spec,
       // meaning the server does not support explicit session termination

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -1,9 +1,7 @@
-import { Transport } from "../shared/transport.js";
+import { Transport, FetchLike } from "../shared/transport.js";
 import { isInitializedNotification, isJSONRPCRequest, isJSONRPCResponse, JSONRPCMessage, JSONRPCMessageSchema } from "../types.js";
 import { auth, AuthResult, extractResourceMetadataUrl, OAuthClientProvider, UnauthorizedError } from "./auth.js";
 import { EventSourceParserStream } from "eventsource-parser/stream";
-
-export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
 
 // Default reconnection options for StreamableHTTP connections
 const DEFAULT_STREAMABLE_HTTP_RECONNECTION_OPTIONS: StreamableHTTPReconnectionOptions = {
@@ -25,7 +23,7 @@ export class StreamableHTTPError extends Error {
 /**
  * Options for starting or authenticating an SSE connection
  */
-interface StartSSEOptions {
+export interface StartSSEOptions {
   /**
    * The resumption token used to continue long-running requests that were interrupted.
    *
@@ -260,15 +258,15 @@ const response = await (this._fetch ?? fetch)(this._url, {
 
     private _normalizeHeaders(headers: HeadersInit | undefined): Record<string, string> {
     if (!headers) return {};
-    
+
     if (headers instanceof Headers) {
       return Object.fromEntries(headers.entries());
     }
-    
+
     if (Array.isArray(headers)) {
       return Object.fromEntries(headers);
     }
-    
+
     return { ...headers as Record<string, string> };
   }
 

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -209,7 +209,7 @@ export class StreamableHTTPClientTransport implements Transport {
         headers.set("last-event-id", resumptionToken);
       }
 
-      const response = await (this._fetch ?? fetch)(this._url, {
+const response = await (this._fetch ?? fetch)(this._url, {
         method: "GET",
         headers,
         signal: this._abortController?.signal,

--- a/src/client/streamableHttp.ts
+++ b/src/client/streamableHttp.ts
@@ -423,7 +423,7 @@ const response = await (this._fetch ?? fetch)(this._url, {
         signal: this._abortController?.signal,
       };
 
-      const response = await (this._fetch ?? fetch)(this._url, init);
+const response = await (this._fetch ?? fetch)(this._url, init);
 
       // Handle session ID received during initialization
       const sessionId = response.headers.get("mcp-session-id");

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,10 +1,12 @@
 import { JSONRPCMessage, MessageExtraInfo, RequestId } from "../types.js";
 
+export type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>;
+
 /**
  * Options for sending a JSON-RPC message.
  */
 export type TransportSendOptions = {
-  /** 
+  /**
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
   relatedRequestId?: RequestId;
@@ -38,7 +40,7 @@ export interface Transport {
 
   /**
    * Sends a JSON-RPC message (request or response).
-   * 
+   *
    * If present, `relatedRequestId` is used to indicate to the transport which incoming request to associate this outgoing message with.
    */
   send(message: JSONRPCMessage, options?: TransportSendOptions): Promise<void>;
@@ -64,9 +66,9 @@ export interface Transport {
 
   /**
    * Callback for when a message (request or response) is received over the connection.
-   * 
+   *
    * Includes the requestInfo and authInfo if the transport is authenticated.
-   * 
+   *
    * The requestInfo can be used to get the original request information (headers, etc.)
    */
   onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;


### PR DESCRIPTION
## Summary
- add a `fetch` option to `SSEClientTransport` and `StreamableHTTPClientTransport`
- use the custom fetch implementation for SSE, HTTP POST and DELETE requests
- ensure custom fetch can add auth headers in tests

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686405a312f48331b41322eb4cee87cb